### PR TITLE
E 1998 - Weights in grade calculations

### DIFF
--- a/app/controllers/questionnaires_controller.rb
+++ b/app/controllers/questionnaires_controller.rb
@@ -190,7 +190,7 @@ class QuestionnairesController < ApplicationController
     ((num_of_existed_questions + 1)..(num_of_existed_questions + params[:question][:total_num].to_i)).each do |i|
       question = Object.const_get(params[:question][:type]).create(txt: '', questionnaire_id: questionnaire_id, seq: i, type: params[:question][:type], break_before: true)
       if question.is_a? ScoredQuestion
-        question.weight = 1
+        question.weight = params[:question][:weight]
         question.max_label = 'Strongly agree'
         question.min_label = 'Strongly disagree'
       end

--- a/app/views/questionnaires/_question_weight.html.erb
+++ b/app/views/questionnaires/_question_weight.html.erb
@@ -1,0 +1,17 @@
+<script type="text/javascript">
+
+    $(document).ready(function () {
+        var ques_type = $("#question_type")[0].value;
+        checkQuestionType();
+    });
+
+    function checkQuestionType() {
+        ques_type = $("#question_type")[0].value;
+        if (ques_type == 'Scale' || ques_type == 'Criterion') {
+            $("#new_question_weight").show();
+        } else {
+            $("#new_question_weight").hide();
+        }
+    }
+
+</script>

--- a/app/views/questionnaires/_questionnaire.html.erb
+++ b/app/views/questionnaires/_questionnaire.html.erb
@@ -44,7 +44,10 @@
                "SectionHeader"=>"SectionHeader",
                "TableHeader"=>"TableHeader",
                "ColumnHeader"=>"ColumnHeader",
-               }, {}, {class: "form-control"} %> question(s)</p>
+               }, {}, {class: "form-control", onchange: "checkQuestionType()"} %> question(s)
+           <span id = "new_question_weight">
+            Add question weight <%= text_field 'question', 'weight', :size => 1, :value => "1", :class => "form-control" %>
+           </span></p>
         <% end %>
       </td>
     </tr>

--- a/app/views/questionnaires/edit.html.erb
+++ b/app/views/questionnaires/edit.html.erb
@@ -1,3 +1,4 @@
+<%= render :partial => 'question_weight' %>
 <h1>Edit <%= @questionnaire.display_type %></h1>
 
 <% if @questionnaire.type == "QuizQuestionnaire" %>


### PR DESCRIPTION
Adding a field to input weights when creating scored questions. This allows weights to be associated with scored questions when creating them unlike before, when questions had to be first created and then edited to change the weights.